### PR TITLE
fix: YumemiWeather.syncFetchWeather からエラーが返るとローディングが終わらない問題の修正

### DIFF
--- a/Example/Example/Model/WeatherModel.swift
+++ b/Example/Example/Model/WeatherModel.swift
@@ -50,6 +50,8 @@ class WeatherModelImpl: WeatherModel {
                     else {
                         completion(.failure(WeatherError.jsonDecodeError))
                     }
+                } else {
+                    completion(.failure(WeatherError.unknownError))
                 }
             }
         }

--- a/Example/Example/Model/WeatherModel.swift
+++ b/Example/Example/Model/WeatherModel.swift
@@ -43,16 +43,17 @@ class WeatherModelImpl: WeatherModel {
         let request = Request(area: area, date: date)
         if let requestJSON = try? jsonString(from: request) {
             DispatchQueue.global().async {
-                if let responseJSON = try? YumemiWeather.syncFetchWeather(requestJSON) {
-                    if let response = try? self.response(from: responseJSON) {
-                        completion(.success(response))
-                    }
-                    else {
-                        completion(.failure(WeatherError.jsonDecodeError))
-                    }
-                } else {
+                guard let responseJSON = try? YumemiWeather.syncFetchWeather(requestJSON) else {
                     completion(.failure(WeatherError.unknownError))
+                    return
                 }
+                
+                guard let response = try? self.response(from: responseJSON) else {
+                    completion(.failure(WeatherError.jsonDecodeError))
+                    return
+                }
+                
+                completion(.success(response))
             }
         }
     }


### PR DESCRIPTION
[Session15: BugFix](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/BugFix.md)

## 対象 Issue
close #3 

## 内容
`YumemiWeather.syncFetchWeather` からエラーが返るとローディングが終わらない問題の修正
- エラーが返ったときに `completion` が呼ばれてなかったので修正

## UI
変更なし

<!--
<img src="" alt="" width="150"/>
-->