### PR TITLE
fix: close #7 - WeatherViewController が解放されずメモリリークする問題の解消

### DIFF
--- a/Example/Example/UI/Weather/WeatherViewController.swift
+++ b/Example/Example/UI/Weather/WeatherViewController.swift
@@ -44,14 +44,14 @@ class WeatherViewController: UIViewController {
     
     @IBAction func loadWeather(_ sender: Any?) {
         activityIndicator.startAnimating()
-        weatherModel.fetchWeather(at: "tokyo", date: Date()) { result in
+        weatherModel.fetchWeather(at: "tokyo", date: Date()) { [weak self] result in
             DispatchQueue.main.async {
-                self.activityIndicator.stopAnimating()
-                self.handleWeather(result: result)
+                self?.activityIndicator.stopAnimating()
+                self?.handleWeather(result: result)
             }
         }
-        disasterModel.fetchDisaster { (disaster) in
-            self.disasterLabel.text = disaster
+        disasterModel.fetchDisaster { [weak self] (disaster) in
+            self?.disasterLabel.text = disaster
         }
     }
     
@@ -74,8 +74,8 @@ class WeatherViewController: UIViewController {
             }
             
             let alertController = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: "OK", style: .default) { _ in
-                self.dismiss(animated: true) {
+            alertController.addAction(UIAlertAction(title: "OK", style: .default) { [weak self] _ in
+                self?.dismiss(animated: true) {
                     print("Close ViewController by \(alertController)")
                 }
             })


### PR DESCRIPTION
[Session15: BugFix](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/BugFix.md)

## 対象 Issue
close #7 

## 内容
`WeatherViewController` が alert の action によって `dismiss` されたとき、インスタンスが解放されない問題の解消
- `self` が絡むクロージャは `self` を弱参照で持たせる

## UI
変更なし

<!--
<img src="" alt="" width="150"/>
-->